### PR TITLE
Add nine-slot machine support

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,8 +72,6 @@
       }
       .reel {
         position: absolute;
-        width: 19.2%;
-        height: 14.4%;
         background: transparent;
         display: flex;
         justify-content: center;
@@ -111,15 +109,57 @@
       }
       #reel1 {
         left: 20.4%;
-        top: 33.9%;
+        top: 16.5%;
+        width: 19.2%;
+        height: 14.4%;
       }
       #reel2 {
         left: 42.7%;
-        top: 33.7%;
+        top: 16.5%;
+        width: 19.2%;
+        height: 14.4%;
       }
       #reel3 {
         left: 65.1%;
+        top: 16.5%;
+        width: 19.2%;
+        height: 14.4%;
+      }
+      #reel4 {
+        left: 20.4%;
         top: 33.9%;
+        width: 19.2%;
+        height: 14.4%;
+      }
+      #reel5 {
+        left: 42.7%;
+        top: 33.9%;
+        width: 19.2%;
+        height: 14.4%;
+      }
+      #reel6 {
+        left: 65.1%;
+        top: 33.9%;
+        width: 19.2%;
+        height: 14.4%;
+      }
+      #reel7 {
+        left: 20.4%;
+        top: 51.3%;
+        width: 19.2%;
+        height: 14.4%;
+      }
+      #reel8 {
+        left: 42.7%;
+        top: 51.3%;
+        width: 19.2%;
+        height: 14.4%;
+      }
+      #reel9 {
+        left: 65.1%;
+        top: 51.3%;
+        width: 19.2%;
+        height: 14.4%;
       }
       .reel img {
         width: 85%;
@@ -333,6 +373,36 @@
             <img src="img/briefcase.png" alt="Briefcase" />
           </div>
         </div>
+        <div id="reel4" class="reel blur-background">
+          <div class="reel-inner">
+            <img src="img/house.png" alt="House" />
+          </div>
+        </div>
+        <div id="reel5" class="reel blur-background">
+          <div class="reel-inner">
+            <img src="img/scroll.png" alt="Scroll" />
+          </div>
+        </div>
+        <div id="reel6" class="reel blur-background">
+          <div class="reel-inner">
+            <img src="img/baby-bottle.png" alt="Bottle" />
+          </div>
+        </div>
+        <div id="reel7" class="reel blur-background">
+          <div class="reel-inner">
+            <img src="img/box.png" alt="Box" />
+          </div>
+        </div>
+        <div id="reel8" class="reel blur-background">
+          <div class="reel-inner">
+            <img src="img/blue heart.png" alt="Blue Heart" />
+          </div>
+        </div>
+        <div id="reel9" class="reel blur-background">
+          <div class="reel-inner">
+            <img src="img/pink heart.png" alt="Pink Heart" />
+          </div>
+        </div>
         <div class="spin-button blur-background" id="spinButton">
           <img src="img/tap to spin.png" alt="Spin" />
         </div>
@@ -438,6 +508,20 @@
           "img/scroll.png",
           "img/baby-bottle.png",
           "img/box.png",
+          "img/blue heart.png",
+          "img/pink heart.png",
+        ];
+
+        const slotData = [
+          { x: 20.4, y: 16.5, w: 19.2, h: 14.4 },
+          { x: 42.7, y: 16.5, w: 19.2, h: 14.4 },
+          { x: 65.1, y: 16.5, w: 19.2, h: 14.4 },
+          { x: 20.4, y: 33.9, w: 19.2, h: 14.4 },
+          { x: 42.7, y: 33.9, w: 19.2, h: 14.4 },
+          { x: 65.1, y: 33.9, w: 19.2, h: 14.4 },
+          { x: 20.4, y: 51.3, w: 19.2, h: 14.4 },
+          { x: 42.7, y: 51.3, w: 19.2, h: 14.4 },
+          { x: 65.1, y: 51.3, w: 19.2, h: 14.4 },
         ];
 
         function getRandomIcon() {
@@ -466,12 +550,19 @@
         }
 
         let spinCount = 0;
-        let currentSymbols = [icons[0], icons[1], icons[2]];
+        let currentSymbols = icons.slice(0, slotData.length);
         const slotMachine = document.getElementById("slotMachine");
         const spinButton = document.getElementById("spinButton");
-        const reel1 = document.getElementById("reel1");
-        const reel2 = document.getElementById("reel2");
-        const reel3 = document.getElementById("reel3");
+        const reels = slotData.map((_, i) => document.getElementById(`reel${i + 1}`));
+        slotData.forEach((slot, i) => {
+          const reel = reels[i];
+          if (reel) {
+            reel.style.left = `${slot.x}%`;
+            reel.style.top = `${slot.y}%`;
+            reel.style.width = `${slot.w}%`;
+            reel.style.height = `${slot.h}%`;
+          }
+        });
         const introOverlay = document.getElementById("introOverlay");
         const introLinesDiv = document.getElementById("introLines");
         const introColorOverlay = introOverlay.querySelector(".color-overlay");
@@ -510,9 +601,7 @@
         function hideInstructionsOverlay() {
           instructionsOverlay.style.opacity = "0";
           slotMachine.classList.remove("blur-background");
-          reel1.classList.remove("blur-background");
-          reel2.classList.remove("blur-background");
-          reel3.classList.remove("blur-background");
+          reels.forEach((r) => r.classList.remove("blur-background"));
           spinButton.classList.remove("blur-background");
           instructionsOverlay.style.pointerEvents = "none";
           setTimeout(() => {
@@ -586,41 +675,35 @@
         function handleSpin() {
           spinCount++;
           spinButton.style.pointerEvents = "none";
-          const reel1Delay = 0,
-            reel2Delay = 600,
-            reel3Delay = 1200,
-            spinDuration = 900;
+          const spinDuration = 900;
+          const delays = reels.map((_, i) => i * 300);
           if (spinCount === 4) {
             const babyBottle = icons[5];
-            spinReel(reel1, reel1Delay, spinDuration, babyBottle);
-            spinReel(reel2, reel2Delay, spinDuration, babyBottle);
-            spinReel(
-              reel3,
-              reel3Delay,
-              spinDuration,
-              babyBottle,
-              () => setTimeout(showReveal, 500),
-            );
-            currentSymbols = [babyBottle, babyBottle, babyBottle];
+            reels.forEach((reel, i) => {
+              const cb =
+                i === reels.length - 1 ? () => setTimeout(showReveal, 500) : null;
+              spinReel(reel, delays[i], spinDuration, babyBottle, cb);
+            });
+            currentSymbols = Array(reels.length).fill(babyBottle);
           } else {
             generateRandomNonMatchingSymbols();
-            spinReel(reel1, reel1Delay, spinDuration, currentSymbols[0]);
-            spinReel(reel2, reel2Delay, spinDuration, currentSymbols[1]);
-            spinReel(reel3, reel3Delay, spinDuration, currentSymbols[2]);
+            reels.forEach((reel, i) => {
+              spinReel(reel, delays[i], spinDuration, currentSymbols[i]);
+            });
           }
           const pointerDelay =
-            reel3Delay + spinDuration + (spinCount === 4 ? 500 : 0);
+            delays[delays.length - 1] + spinDuration + (spinCount === 4 ? 500 : 0);
           setTimeout(() => {
             spinButton.style.pointerEvents = "auto";
           }, pointerDelay);
         }
         function generateRandomNonMatchingSymbols() {
-          let idx = [];
-          while (idx.length < 3) {
-            let r = Math.floor(Math.random() * icons.length);
+          const idx = [];
+          while (idx.length < reels.length) {
+            const r = Math.floor(Math.random() * icons.length);
             if (!idx.includes(r)) idx.push(r);
           }
-          currentSymbols = [icons[idx[0]], icons[idx[1]], icons[idx[2]]];
+          currentSymbols = idx.map((i) => icons[i]);
         }
         function spinReel(reel, delay, duration, finalIcon, callback) {
           setTimeout(() => {


### PR DESCRIPTION
## Summary
- add six more slot reels
- manage reel positioning via `slotData`
- include extra icons for reels
- spin all reels using a loop

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686a0cfbb124832fa61839849fdbc562