### PR TITLE
Fix blocked instructions overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -515,9 +515,6 @@
           { x: 20.4, y: 51.3, w: 19.2, h: 14.4 },
           { x: 42.7, y: 51.3, w: 19.2, h: 14.4 },
           { x: 65.1, y: 51.3, w: 19.2, h: 14.4 },
-=======
-          "img/blue heart.png",
-          "img/pink heart.png",
         ];
 
         function getRandomIcon() {


### PR DESCRIPTION
## Summary
- remove stray conflict markers from `index.html`

The leftover `=======` markers after a merge conflict broke the HTML script, preventing the instructions overlay from responding.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686aa5855758832faf88fcd7723e3239