### PR TITLE
Remove outdated slot icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,47 +367,47 @@
         <div class="slot-machine blur-background" id="slotMachine"></div>
         <div id="reel1" class="reel blur-background">
           <div class="reel-inner">
-            <img src="img/ring.png" alt="Ring" />
+            <img src="img/blue heart.png" alt="Blue Heart" />
           </div>
         </div>
         <div id="reel2" class="reel blur-background">
           <div class="reel-inner">
-            <img src="img/graduation cap.png" alt="Graduation" />
+            <img src="img/pink heart.png" alt="Pink Heart" />
           </div>
         </div>
         <div id="reel3" class="reel blur-background">
           <div class="reel-inner">
-            <img src="img/briefcase.png" alt="Briefcase" />
+            <img src="img/blue heart.png" alt="Blue Heart" />
           </div>
         </div>
         <div id="reel4" class="reel blur-background">
           <div class="reel-inner">
-            <img src="img/house.png" alt="House" />
+            <img src="img/pink heart.png" alt="Pink Heart" />
           </div>
         </div>
         <div id="reel5" class="reel blur-background">
           <div class="reel-inner">
-            <img src="img/scroll.png" alt="Scroll" />
+            <img src="img/blue heart.png" alt="Blue Heart" />
           </div>
         </div>
         <div id="reel6" class="reel blur-background">
           <div class="reel-inner">
-            <img src="img/baby-bottle.png" alt="Bottle" />
+            <img src="img/pink heart.png" alt="Pink Heart" />
           </div>
         </div>
         <div id="reel7" class="reel blur-background">
           <div class="reel-inner">
-            <img src="img/box.png" alt="Box" />
+            <img src="img/blue heart.png" alt="Blue Heart" />
           </div>
         </div>
         <div id="reel8" class="reel blur-background">
           <div class="reel-inner">
-            <img src="img/blue heart.png" alt="Blue Heart" />
+            <img src="img/pink heart.png" alt="Pink Heart" />
           </div>
         </div>
         <div id="reel9" class="reel blur-background">
           <div class="reel-inner">
-            <img src="img/pink heart.png" alt="Pink Heart" />
+            <img src="img/blue heart.png" alt="Blue Heart" />
           </div>
         </div>
         <div class="spin-button blur-background" id="spinButton">


### PR DESCRIPTION
## Summary
- remove old slot images so only heart icons are referenced

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686ade229cb4832fa92784302685ca50