### PR TITLE
Prevent matching rows before final spin

### DIFF
--- a/index.html
+++ b/index.html
@@ -776,11 +776,26 @@
           }, pointerDelay);
         }
         function generateRandomNonMatchingSymbols() {
+          function hasMatchingRow(symbols) {
+            for (let r = 0; r < 3; r++) {
+              const i = r * 3;
+              if (
+                symbols[i] === symbols[i + 1] &&
+                symbols[i] === symbols[i + 2]
+              ) {
+                return true;
+              }
+            }
+            return false;
+          }
           do {
             currentSymbols = Array.from({ length: reels.length }, () =>
               getRandomIcon()
             );
-          } while (currentSymbols.every((s) => s === currentSymbols[0]));
+          } while (
+            currentSymbols.every((s) => s === currentSymbols[0]) ||
+            (spinCount < 4 && hasMatchingRow(currentSymbols))
+          );
         }
         function spinReel(reel, delay, duration, finalIcon, callback) {
           setTimeout(() => {


### PR DESCRIPTION
## Summary
- ensure generateRandomNonMatchingSymbols avoids three-of-a-kind rows for the first three spins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686adfb8324c832fa246d9c3d8e3b493