### PR TITLE
Fix reel blur and adjust spin animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
       }
       .reel {
         position: absolute;
-        background: transparent;
+        background: rgba(255, 255, 255, 0.2);
         display: flex;
         justify-content: center;
         align-items: center;
@@ -98,14 +98,14 @@
       }
       @keyframes slot-spin-down {
         0% {
-          transform: translateY(-20%);
+          transform: translateY(-100%);
         }
         100% {
-          transform: translateY(0);
+          transform: translateY(100%);
         }
       }
       .reel-strip.spinning {
-        animation: slot-spin-down 0.2s linear infinite;
+        animation: slot-spin-down 0.6s linear infinite;
       }
       .reel-strip {
         display: flex;
@@ -375,15 +375,15 @@
     <div class="aspect-container">
       <div class="slot-machine-container">
         <div class="slot-machine blur-background" id="slotMachine"></div>
-        <div id="reel1" class="reel blur-background"></div>
-        <div id="reel2" class="reel blur-background"></div>
-        <div id="reel3" class="reel blur-background"></div>
-        <div id="reel4" class="reel blur-background"></div>
-        <div id="reel5" class="reel blur-background"></div>
-        <div id="reel6" class="reel blur-background"></div>
-        <div id="reel7" class="reel blur-background"></div>
-        <div id="reel8" class="reel blur-background"></div>
-        <div id="reel9" class="reel blur-background"></div>
+        <div id="reel1" class="reel"></div>
+        <div id="reel2" class="reel"></div>
+        <div id="reel3" class="reel"></div>
+        <div id="reel4" class="reel"></div>
+        <div id="reel5" class="reel"></div>
+        <div id="reel6" class="reel"></div>
+        <div id="reel7" class="reel"></div>
+        <div id="reel8" class="reel"></div>
+        <div id="reel9" class="reel"></div>
         <div class="spin-button blur-background" id="spinButton">
           <img src="img/tap to spin.png" alt="Spin" />
         </div>
@@ -793,6 +793,7 @@
             strip.classList.add("spinning");
             setTimeout(() => {
               strip.classList.remove("spinning");
+              reel.innerHTML = "";
               createSingleIcon(reel, finalIcon || getRandomIcon());
               if (callback) callback();
             }, duration);


### PR DESCRIPTION
## Summary
- remove `blur-background` class from reels so they don't stay blurred after the intro
- slow down the reel spin animation and give it a larger range
- add a light background to reels for layering debug
- clear reel contents when replacing the spinning strip

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_686af76f5110832fbcb7a720c57f77a8