### PR TITLE
Improve reel spin smoothness

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
         }
       }
       .reel-strip.spinning {
-        animation: slot-spin-down 0.6s cubic-bezier(.4, .15, .3, .95) infinite;
+        animation: slot-spin-down 1s linear infinite;
       }
       .reel-strip {
         display: flex;
@@ -766,7 +766,7 @@
         function handleSpin() {
           spinCount++;
           spinButton.style.pointerEvents = "none";
-          const spinDuration = 900;
+          const spinDuration = 1000;
           const delays = reels.map((_, i) => i * 300);
           if (spinCount === 4) {
             const pinkHeart = icons[1];


### PR DESCRIPTION
## Summary
- smooth out slot machine animation timing
- spin reels for a longer duration to match the new CSS animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686b2ec4cb64832faaf94090657e30a3