### PR TITLE
Fix top row overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -527,9 +527,9 @@
 
         document.addEventListener("DOMContentLoaded", function () {
           const slotData = [
-            { row: 1, col: 1, xPct: 20.00, yPct: 42.69, wPct: 18.70, hPct: 8.26 },
-            { row: 1, col: 2, xPct: 41.43, yPct: 42.86, wPct: 18.70, hPct: 8.07 },
-            { row: 1, col: 3, xPct: 63.52, yPct: 42.86, wPct: 16.44, hPct: 8.07 },
+            { row: 1, col: 1, xPct: 20.00, yPct: 42.69, wPct: 18.70, hPct: 7.80 },
+            { row: 1, col: 2, xPct: 41.43, yPct: 42.86, wPct: 18.70, hPct: 7.80 },
+            { row: 1, col: 3, xPct: 63.52, yPct: 42.86, wPct: 16.44, hPct: 7.80 },
 
             { row: 2, col: 1, xPct: 19.58, yPct: 51.83, wPct: 17.69, hPct: 6.66 },
             { row: 2, col: 2, xPct: 41.15, yPct: 51.83, wPct: 19.20, hPct: 6.66 },


### PR DESCRIPTION
## Summary
- shrink the height of the top row reels so they stay within the bounds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686b35ef339c832fbfd988ddd63b7b32