### PR TITLE
Update spin button image and position

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
         width: 34%;
         max-width: 170px;
         left: 50%;
-        top: 62.5%;
+        top: 82.5%;
         transform: translateX(-50%);
         cursor: pointer;
         filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.18));
@@ -394,7 +394,7 @@
         <div id="reel8" class="reel"></div>
         <div id="reel9" class="reel"></div>
         <div class="spin-button blur-background" id="spinButton">
-          <img src="img/tap to spin.png" alt="Spin" />
+          <img src="img/button.png" alt="Spin" />
         </div>
         <div class="reveal-overlay intro-overlay" id="introOverlay">
           <div class="color-overlay"></div>


### PR DESCRIPTION
## Summary
- replace the 'tap to spin' button graphic with `img/button.png`
- move the spin button 20% lower on the page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686b4142a624832f91fc2a89518306f1