### PR TITLE
Add customizable finalHeart parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ xdg-open index.html        # Linux
 - `mainBold`, `subBold`, `dateBold`, `fromBold` – set to `1` or `true` to make a line bold, `0` or `false` for normal weight.
 - `mainItalic`, `subItalic`, `dateItalic`, `fromItalic` – set to `1` to italicize a line.
 - `mainCaps`, `subCaps`, `dateCaps`, `fromCaps` – set to `1` to force uppercase or `0` to disable the default uppercase styling.
+- `finalHeart` – choose the heart icon shown on the last spin. Use `blue`, `pink`, `0`, or `1` (where `0` is blue).
 
 `color` only affects the overlay background, whereas `textColor` and `outlineColor` control the message text and its outline.
 
@@ -58,6 +59,10 @@ index.html?main=We%27re%20expecting%21&sub=Baby%20Miller%20%233&date=Arriving%20
 
 ```
 index.html?main=Surprise!&mainTextColor=coral&mainOutlineColor=%23000000&sub=coming%20soon&subCaps=0&subItalic=1
+```
+
+```
+index.html?main=The%20Big%20Reveal&finalHeart=blue
 ```
 
 Open one of these URLs in your browser to see the customized reveal.

--- a/index.html
+++ b/index.html
@@ -427,7 +427,11 @@
         for (const [k, v] of url.searchParams.entries()) {
           // Normalize keys to lower case
           const key = k.toLowerCase();
-          const value = v.replace(/\+/g, " ");
+          let value = v.replace(/\+/g, " ");
+          if (key === "finalheart") {
+            value = value.toLowerCase();
+            if (!["blue", "pink", "0", "1"].includes(value)) continue;
+          }
           params[key] = value;
           // Preserve original casing for backward compatibility
           if (key !== k) params[k] = value;
@@ -788,13 +792,15 @@
           const spinDuration = 1000;
           const delays = reels.map((_, i) => i * 300);
           if (spinCount === 4) {
-            const pinkHeart = heartIcons[1];
+            const finalIndex =
+              params.finalheart === "blue" || params.finalheart === "0" ? 0 : 1;
+            const finalHeart = heartIcons[finalIndex];
             reels.forEach((reel, i) => {
               const cb =
                 i === reels.length - 1 ? () => setTimeout(showReveal, 500) : null;
-              spinReel(reel, delays[i], spinDuration, pinkHeart, cb, slotData[i].row);
+              spinReel(reel, delays[i], spinDuration, finalHeart, cb, slotData[i].row);
             });
-            currentSymbols = Array(reels.length).fill(pinkHeart);
+            currentSymbols = Array(reels.length).fill(finalHeart);
 
           } else {
             generateRandomNonMatchingSymbols();


### PR DESCRIPTION
## Summary
- parse `finalheart` query parameter and validate values
- allow final spin to use blue or pink heart depending on the parameter
- document `finalHeart` option in README with an example link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686c29af4888832fb6b86a4628ed340c