### PR TITLE
Add finalHeart URL parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ xdg-open index.html        # Linux
 - `photo` – URL to an image shown as a circular avatar
 - `from` – a closing signature line
 - `color` – overlay color when the message appears. Allowed values: `beige` (default), `pink`, `blue`, `yellow`, `green`, `purple`, `gold`, `white`, `none`. You can also supply any valid hex or CSS color value for a custom overlay.
+- `finalHeart` – heart icon used for the final winning spin. Use `0` or `blue` for a blue heart, `1` or `pink` for a pink heart (defaults to pink).
 - `textColor` – color for the message text (any valid CSS color value)
 - `outlineColor` – color for the outline around the message text
 - `font` – Google Fonts family name to use for all text (e.g. `font=Playfair+Display`)

--- a/index.html
+++ b/index.html
@@ -646,6 +646,13 @@
         const params = getParams();
         const safeTextColor = sanitizeColor(params.textcolor, "#ffffff");
         const safeOutlineColor = sanitizeColor(params.outlinecolor, "#7e5e4f");
+        const finalHeartParam = params.finalheart;
+        const finalHeartIndex = /^(0|blue)$/i.test(finalHeartParam || "")
+          ? 0
+          : /^(1|pink)$/i.test(finalHeartParam || "")
+            ? 1
+            : 1;
+        const finalHeartIcon = heartIcons[finalHeartIndex];
         const audioContext = new (window.AudioContext ||
           window.webkitAudioContext)();
 
@@ -788,13 +795,12 @@
           const spinDuration = 1000;
           const delays = reels.map((_, i) => i * 300);
           if (spinCount === 4) {
-            const pinkHeart = heartIcons[1];
             reels.forEach((reel, i) => {
               const cb =
                 i === reels.length - 1 ? () => setTimeout(showReveal, 500) : null;
-              spinReel(reel, delays[i], spinDuration, pinkHeart, cb, slotData[i].row);
+              spinReel(reel, delays[i], spinDuration, finalHeartIcon, cb, slotData[i].row);
             });
-            currentSymbols = Array(reels.length).fill(pinkHeart);
+            currentSymbols = Array(reels.length).fill(finalHeartIcon);
 
           } else {
             generateRandomNonMatchingSymbols();


### PR DESCRIPTION
## Summary
- allow customizing the final heart via `finalHeart` query param
- use that heart icon on the 4th spin
- document the new parameter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686c3058f278832fb252d991511ac2a4