### PR TITLE
Add default overlay color when finalHeart provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ xdg-open index.html        # Linux
 - `photo` – URL to an image shown as a circular avatar
 - `from` – a closing signature line
 - `color` – overlay color when the message appears. Allowed values: `beige` (default), `pink`, `blue`, `yellow`, `green`, `purple`, `gold`, `white`, `none`. You can also supply any valid hex or CSS color value for a custom overlay.
-- `finalHeart` – heart icon used for the final winning spin. Use `0` or `blue` for a blue heart, `1` or `pink` for a pink heart (defaults to pink).
+- `finalHeart` – heart icon used for the final winning spin. Use `0` or `blue` for a blue heart, `1` or `pink` for a pink heart (defaults to pink). If `color` is omitted, the overlay will match the heart color.
 - `textColor` – color for the message text (any valid CSS color value)
 - `outlineColor` – color for the outline around the message text
 - `font` – Google Fonts family name to use for all text (e.g. `font=Playfair+Display`)

--- a/index.html
+++ b/index.html
@@ -657,6 +657,13 @@
         const hasNonHeartParams = Object.keys(params).some(
           (k) => k.toLowerCase() !== "finalheart",
         );
+
+        // Default overlay color based on the final heart when no color is supplied
+        if (!params.color && finalHeartParam) {
+          if (/^(0|blue)$/i.test(finalHeartParam)) params.color = "blue";
+          else if (/^(1|pink)$/i.test(finalHeartParam)) params.color = "pink";
+        }
+
         if (finalHeartIndex === 0 && !hasNonHeartParams) {
           params.main = "IT’S A BOY!";
           if (!params.textcolor) params.textcolor = "#ffffff";


### PR DESCRIPTION
## Summary
- match the overlay color to the final heart when no `color` parameter is supplied
- clarify README on how `finalHeart` now influences the background

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_b_686c96cb6fcc832f847511cde2e1c6a4